### PR TITLE
updated the examples for latest Intersight.PowerShell module v1.0.9.4375

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,11 @@
 Each folder contains a README explaining the contents of that folder.
 
 Always refer to [https://intersight.com/apidocs/downloads/](https://intersight.com/apidocs/downloads/) to find the latest version of the Intersight PowerShell SDK.
+
+## Install the Intersight PowerShell module from PSGallery
+```powershell
+Install-Module -Name Intersight.PowerShell
+```
+
+Refer to [examples](https://github.com/CiscoDevNet/intersight-powershell/tree/master/examples) for more cmdlet example.
+ 

--- a/audit-examples/README.md
+++ b/audit-examples/README.md
@@ -2,7 +2,7 @@
 
 ## Authorization
 
-Authorization is performed by every Intersight cmdlet. You must properly configure the Intersight PowerShell module parameters using the `Set-IntersightConfigurationHttpSigning` cmdlet as described in the [Getting Started](https://github.com/CiscoDevNet/intersight-powershell/blob/master/GettingStarted.md) page of the Intersight module code.
+Authorization is performed by every Intersight cmdlet. You must properly configure the Intersight PowerShell module parameters using the `Set-IntersightConfiguration` cmdlet as described in the [Getting Started](https://github.com/CiscoDevNet/intersight-powershell/blob/master/GettingStarted.md) page of the Intersight module code.
 
 ## Examples
 

--- a/audit-examples/audit-deleted-objects.ps1
+++ b/audit-examples/audit-deleted-objects.ps1
@@ -1,5 +1,5 @@
 <#
-Copyright (c) 2018 Cisco and/or its affiliates.
+Copyright (c) 2021 Cisco and/or its affiliates.
 This software is licensed to you under the terms of the Cisco Sample
 Code License, Version 1.0 (the "License"). You may obtain a copy of the
 License at
@@ -15,7 +15,7 @@ or implied.
 # This script captures the entire audit history of a managed object specified
 # by its Moid (managed object ID).
 
-# the only required parameter is $Moid
+# the only required parameter is days
 [cmdletbinding()]
 param(
     [parameter(Mandatory=$true)]
@@ -25,11 +25,11 @@ param(
 # retrieve the audit log for all delete entries for the last X days
 $mydate = (Get-Date).AddDays(-$Days).ToString("yyyy-MM-ddTHH:mm:ss.fffZ")
 $myfilter = "Event eq Deleted and CreateTime gt $mydate"
-$data = (Get-IntersightAaaAuditRecordList `
-        -VarFilter $myfilter `
+$data = (Get-IntersightAaaAuditRecord `
+        -Filter $myfilter `
         -Orderby CreateTime `
         -Select 'CreateTime,Email,MoDisplayNames'
-    ).ActualInstance.Results
+    ).Results
 
 # add the name of the deleted object to each "row" of results from the API
 foreach($obj in $data) 

--- a/audit-examples/audit-moid-history.ps1
+++ b/audit-examples/audit-moid-history.ps1
@@ -1,5 +1,5 @@
 <#
-Copyright (c) 2018 Cisco and/or its affiliates.
+Copyright (c) 2021 Cisco and/or its affiliates.
 This software is licensed to you under the terms of the Cisco Sample
 Code License, Version 1.0 (the "License"). You may obtain a copy of the
 License at
@@ -26,11 +26,11 @@ param(
 # matches the specified Moid
 $moid_filter = "ObjectMoid eq '$($Moid)'"
 
-$data = (Get-IntersightAaaAuditRecordList `
-    -VarFilter $moid_filter `
+$data = (Get-IntersightAaaAuditRecord `
+    -Filter $moid_filter `
     -Select 'Email,CreateTime,Event,Request' `
     -Orderby CreateTime `
-    ).ActualInstance.Results
+    ).Results
 
 # Write each audit log entry to its own file in JSON format with the date of
 # the event as the filename.

--- a/audit-examples/audit-user-summary.ps1
+++ b/audit-examples/audit-user-summary.ps1
@@ -1,5 +1,5 @@
 <#
-Copyright (c) 2018 Cisco and/or its affiliates.
+Copyright (c) 2021 Cisco and/or its affiliates.
 This software is licensed to you under the terms of the Cisco Sample
 Code License, Version 1.0 (the "License"). You may obtain a copy of the
 License at
@@ -20,8 +20,8 @@ param(
 )
 
 # get and display the most recent audit log for a given user
-(Get-IntersightAaaAuditRecordList `
-    -VarFilter "contains(Email, '$($Email)')" `
+(Get-IntersightAaaAuditRecord `
+    -Filter "contains(Email, '$($Email)')" `
     -Apply 'groupby((MoType), aggregate(CreateTime with max as Latest))' `
     -Orderby Latest `
-).ActualInstance.Results
+).Results

--- a/policy-examples/README.md
+++ b/policy-examples/README.md
@@ -2,7 +2,7 @@
 
 ## Authorization
 
-Authorization is performed by every Intersight cmdlet. You must properly configure the Intersight PowerShell module parameters using the `Set-IntersightConfigurationHttpSigning` cmdlet as described in the [Getting Started](https://github.com/CiscoDevNet/intersight-powershell/blob/master/GettingStarted.md) page of the Intersight module code.
+Authorization is performed by every Intersight cmdlet. You must properly configure the Intersight PowerShell module parameters using the `Set-IntersightConfiguration` cmdlet as described in the [Getting Started](https://github.com/CiscoDevNet/intersight-powershell/blob/master/GettingStarted.md) page of the Intersight module code.
 
 ## Examples
 

--- a/tag-examples/README.md
+++ b/tag-examples/README.md
@@ -2,7 +2,7 @@
 
 ## Authorization
 
-Authorization is performed by every Intersight cmdlet. You must properly configure the Intersight PowerShell module parameters using the `Set-IntersightConfigurationHttpSigning` cmdlet as described in the [Getting Started](https://github.com/CiscoDevNet/intersight-powershell/blob/master/GettingStarted.md) page of the Intersight module code.
+Authorization is performed by every Intersight cmdlet. You must properly configure the Intersight PowerShell module parameters using the `Set-IntersightConfiguration` cmdlet as described in the [Getting Started](https://github.com/CiscoDevNet/intersight-powershell/blob/master/GettingStarted.md) page of the Intersight module code.
 
 ## Examples
 
@@ -22,7 +22,7 @@ This script depends on the file `classes.csv` and will only update those object 
 
 This script **overwrites** a server's tags with the tags specified in a CSV file. 
 
-```bash
+```powershell
 tag-servers-csv.ps1 -CsvFile servers.csv
 ```
 
@@ -50,6 +50,6 @@ Here is an example with sample values in it. To add more tags, simply add more c
 
 This script adds the specified tag to every server in your Intersight account whose locator LED is turned on. This preserves all existing tags. The tag key and value are specified when calling the script as shown below.
 
-```bash
+```powershell
 tag-servers-locator.ps1 -Key location -Value austin
 ```

--- a/tag-examples/classes.csv
+++ b/tag-examples/classes.csv
@@ -1,12 +1,12 @@
 classid,getcmd,setcmd
-bios.Policy,Get-IntersightBiosPolicyList,Set-IntersightBiosPolicy -BiosPolicy $new_policy -Moid $moid
-deviceconnector.Policy,Get-IntersightDeviceconnectorPolicyList,Set-IntersightDeviceconnectorPolicy -DeviceconnectorPolicy $new_policy -Moid $moid
-kvm.Policy,Get-IntersightKvmPolicyList,Set-IntersightKvmPolicy -KvmPolicy $new_policy -Moid $moid
-ntp.Policy,Get-IntersightNtpPolicyList,Set-IntersightNtpPolicy -NtpPolicy $new_policy -Moid $moid
-vnic.LanConnectivityPolicy,Get-IntersightVnicLanConnectivityPolicyList,Set-IntersightVnicLanConnectivityPolicy -VnicLanConnectivityPolicy $new_policy -Moid $moid
-vmedia.Policy,Get-IntersightVmediaPolicyList,Set-IntersightVmediaPolicy -VmediaPolicy $new_policy -Moid $moid
-hyperflex.ClusterProfile,Get-IntersightHyperflexClusterProfileList,Set-IntersightHyperflexClusterProfile -HyperflexClusterProfile $new_policy -Moid $moid
-server.Profile,Get-IntersightServerProfileList,Set-IntersightServerProfile -ServerProfile $new_policy -Moid $moid
-storage.StoragePolicy,Get-IntersightStorageStoragePolicyList,Set-IntersightStorageStoragePolicy $new_policy -Moid $moid
-kubernetes.ClusterProfile,Get-IntersightKubernetesClusterProfileList,Set-IntersightKubernetesClusterProfile $new_policy -Moid $moid
-macpool.Pool,Get-IntersightMacpoolPoolList,Set-IntersightMacpoolPool $new_policy -Moid $moid
+bios.Policy,Get-IntersightBiosPolicyList,Set-IntersightBiosPolicy -Tags $new_tags -Moid $moid
+deviceconnector.Policy,Get-IntersightDeviceconnectorPolicyList,Set-IntersightDeviceconnectorPolicy -Tags $new_tags -Moid $moid
+kvm.Policy,Get-IntersightKvmPolicyList,Set-IntersightKvmPolicy -Tags $new_tags -Moid $moid
+ntp.Policy,Get-IntersightNtpPolicyList,Set-IntersightNtpPolicy -Tags $new_tags -Moid $moid
+vnic.LanConnectivityPolicy,Get-IntersightVnicLanConnectivityPolicyList,Set-IntersightVnicLanConnectivityPolicy -Tags $new_tags -Moid $moid
+vmedia.Policy,Get-IntersightVmediaPolicyList,Set-IntersightVmediaPolicy -Tags $new_tags -Moid $moid
+hyperflex.ClusterProfile,Get-IntersightHyperflexClusterProfileList,Set-IntersightHyperflexClusterProfile -Tags $new_tags -Moid $moid
+server.Profile,Get-IntersightServerProfileList,Set-IntersightServerProfile -Tags $new_tags -Moid $moid
+storage.StoragePolicy,Get-IntersightStorageStoragePolicyList,Set-IntersightStorageStoragePolicy -Tags $new_tags -Moid $moid
+kubernetes.ClusterProfile,Get-IntersightKubernetesClusterProfileList,Set-IntersightKubernetesClusterProfile -Tags $new_tags -Moid $moid
+macpool.Pool,Get-IntersightMacpoolPoolList,Set-IntersightMacpoolPool -Tags $new_tags -Moid $moid

--- a/tag-examples/tag-servers-locator.ps1
+++ b/tag-examples/tag-servers-locator.ps1
@@ -29,7 +29,7 @@ $myfilter = "Parent.ObjectType eq compute.RackUnit and OperState eq on"
 # Using our filter and -Expand to return the ComputeRackUnit will give us the
 # Moid and the existing Tags for the server so we don't have to do an
 # additional get operation. 
-$results = (Get-IntersightEquipmentLocatorLedList -VarFilter $myfilter -Select ComputeRackUnit -Expand ComputeRackUnit).ActualInstance.Results
+$results = (Get-IntersightEquipmentLocatorLed -Filter $myfilter -Select ComputeRackUnit -Expand ComputeRackUnit).Results
 
 foreach ($server in $results)
 {
@@ -41,12 +41,11 @@ foreach ($server in $results)
     {
         if($t.Key -notmatch $Key) { $new_tags += $t }
     }
-    $new_tags += New-Object PSObject -Property @{Key=$Key; Value=$Value}
+    $new_tags += Initialize-IntersightMoTag -Key $Key -Value $Value
     
     # apply the new tags to the server, overwriting all existing tags
-    $settings = @{Tags=$new_tags}
     $moid = $server.ComputeRackUnit.Moid
-    (Set-IntersightComputeRackUnit -Moid $moid -ComputeRackUnit $settings).Serial
+    (Set-IntersightComputeRackUnit -Moid $moid -Tags $new_tags).Serial
     Write-Verbose "$($new_tags.Count) tags now exist for this server"
 }
 


### PR DESCRIPTION
Updated the samples with followings
-> Change made to make the existing script compatible with latest Intersight.PowerShell module.
-> Get Cmdlet name changed
-> Get return type changed.
-> New cmdlet expose the MO properties as parameters, like Initialize-IntersightNtpPolicy is not required to get the ntpPolicy object. New-IntersightNtpPolicy exposes all the properties of NtpPolicy as Parameters.  