### PR TITLE
CSCwk19919: Standard NVM Express Controller not picked up by ODT

### DIFF
--- a/os-discovery-tool/getWindowsOsInvToIntersight.ps1
+++ b/os-discovery-tool/getWindowsOsInvToIntersight.ps1
@@ -368,6 +368,7 @@ Function GetDriverDetails {
                         $_.devicename -like "*AHCI*" -or
                         $_.devicename -like "*Modular Raid*" -or
                         $_.devicename -like "*NVMe*" -or
+                        $_.devicename -like "*NVM Express*" -or
                         $_.devicename -like "*U.2*" -or
                         $_.devicename -like "*LOM*" -or
                         $_.devicename -like "*SAS HBA*" -or
@@ -405,7 +406,7 @@ Function GetDriverDetails {
             $osInv | Add-Member -type NoteProperty -name Value -Value $storage_device_map["SAS HBA"]
         }
         elseif(($storageController.DeviceName -like "*NVMe*") -or
-               ($storageController.DeviceName -like "*U.2*"))
+               ($storageController.DeviceName -like "*U.2*") -or ($storageController.DeviceName -like "*NVM Express*"))
         {
             $osInv | Add-Member -type NoteProperty -name Value -Value $storage_device_map["NVMe"]
         }


### PR DESCRIPTION
**ISSUE:** Storage controller 'Standard NVM Express Controller' was not picked up by ODT.
**Root cause:** String used for finding NVMe Device controller was '*NVMe*' and it did not matched with the current name and caused the issue.
**Fix:** Included 'NVM Express' as part of the string search in device name which fixed the issue. Driver details getting populated to intersight.

**E.g:**
```
   {
      "Key": "intersight.server.os.driver.1.name",
      "Value": "Flash"
    },
    {
      "Key": "intersight.server.os.driver.1.description",
      "Value": "Standard NVM Express Controller"
    },
    {
      "Key": "intersight.server.os.driver.1.version",
      "Value": "10.0.20348.2227"
    }
```