### PR TITLE
CSCwk51078: driver name wrongly specified for UCSC-RAID-HP adapter

### DIFF
--- a/os-discovery-tool/getWindowsOsInvToIntersight.ps1
+++ b/os-discovery-tool/getWindowsOsInvToIntersight.ps1
@@ -89,6 +89,7 @@ $storage_device_map = @{
     "LOM"            = "LOM";
     "Inter(R) i350"  = "LOM";
     "QLogic"         = "Fibre Channel";
+    "mpi3x"          = "mpi3x";
 }
 
 $datestring = (get-date).toUniversalTime().ToFileTimeUtc()
@@ -391,7 +392,14 @@ Function GetDriverDetails {
                 $storageController.DeviceName -like "*SAS RAID*" -or
                 $storageController.DeviceName -like "*RAID SAS*")
         {
-            $osInv | Add-Member -type NoteProperty -name Value -Value $storage_device_map["MEGARAID"]
+            if ($storageController.DeviceName -like "*Tri-Mode*")
+            {
+                $osInv | Add-Member -type NoteProperty -name Value -Value $storage_device_map["mpi3x"]
+            }
+            else
+            {
+                $osInv | Add-Member -type NoteProperty -name Value -Value $storage_device_map["MEGARAID"]
+            }
         }
         elseif($storageController.DeviceName -like "*AHCI*")
         {


### PR DESCRIPTION
**ISSUE:** driver name wrongly specified for UCSC-RAID-HP adapter
**Root cause:** driver name specified as "SAS RAID" for all the "SAS RAID" controller, but for "UCSC-RAID-HP: Cisco Tri-Mode 24G SAS RAID Controller w/4GB Cache " driver it should be "mpi3x"
**Note:** it is more of an enhancement than issue, since we never supported "UCSC-RAID-HP" driver in windows.
**Fix:** for "Tri-Mode", the driver name changed to "mpi3x"

**E.g:** ODT output
```
    {
      "Key": "intersight.server.os.driver.1.name",
      "Value": "mpi3x"
    },
    {
      "Key": "intersight.server.os.driver.1.description",
      "Value": "Cisco Tri-Mode 24G SAS RAID Controller w/4GB Cache"
    },
    {
      "Key": "intersight.server.os.driver.1.version",
      "Value": "8.6.3.0"
    }
```