### PR TITLE
CSCwk27938: To get driver name from OS for RAID

### DIFF
--- a/os-discovery-tool/getWindowsOsInvToIntersight.ps1
+++ b/os-discovery-tool/getWindowsOsInvToIntersight.ps1
@@ -81,7 +81,6 @@ try {
 
 $storage_device_map = @{
     "SWRAID"         = "RAID";
-    "MEGARAID"       = "SAS RAID";
     "AHCI"           = "ahci";
     "Modular Raid"   = "SAS RAID";
     "SAS HBA"        = "SAS HBA";
@@ -402,7 +401,7 @@ Function GetDriverDetails {
             }
             else
             {
-                $osInv | Add-Member -type NoteProperty -name Value -Value $storage_device_map["MEGARAID"]
+                $osInv | Add-Member -type NoteProperty -name Value -Value $stdrivername.DriverName
             }
         }
         elseif($storageController.DeviceName -like "*AHCI*")


### PR DESCRIPTION
**ISSUE:** For all Megaraid, powershell ODT sends driver name as "SAS RAID"
**Fix:** Fetched the driver name from OS for all Megaraid.

E.g: ODT output..
```
    {
      "Key": "intersight.server.os.driver.4.version",
      "Value": "7.716.2.0"
    },
    {
      "Key": "intersight.server.os.driver.4.description",
      "Value": "Broadcom MegaRAID SAS Adapter Aero"
    },
    {
      "Key": "intersight.server.os.driver.4.name",
      "Value": "megasas35i"
    }
```