### PR TITLE
Added support for all Intel ethernet network adapter e810 series

### DIFF
--- a/os-discovery-tool/getWindowsOsInvToIntersight.ps1
+++ b/os-discovery-tool/getWindowsOsInvToIntersight.ps1
@@ -379,7 +379,8 @@ Function GetDriverDetails {
                         $_.devicename -like "*S3260 Dual Pass Through*" -or
                         $_.devicename -like "*QLogic*" -or
                         $_.devicename -like "*X710T2LG*" -or
-                        $_.devicename -like "*E810XXVDA4*"
+                        $_.devicename -like "*E810XXVDA4*" -or
+                        $_.devicename -like "*E810CQDA2*"
                     }
 
     foreach ($storageController in $storageControllerList) {
@@ -440,7 +441,8 @@ Function GetDriverDetails {
             $osInv | Add-Member -type NoteProperty -name Value -Value $storage_device_map["QLogic"]
         }
         elseif(($storageController.DeviceName -like "*X710T2LG*") -or
-                ($storageController.DeviceName -like "*E810XXVDA4*"))
+                ($storageController.DeviceName -like "*E810XXVDA4*") -or
+                ($storageController.DeviceName -like "*E810CQDA2*"))
         {
             $osInv | Add-Member -type NoteProperty -name Value -Value $storage_device_map["Ethernet"]
         }

--- a/os-discovery-tool/getWindowsOsInvToIntersight.ps1
+++ b/os-discovery-tool/getWindowsOsInvToIntersight.ps1
@@ -379,8 +379,7 @@ Function GetDriverDetails {
                         $_.devicename -like "*S3260 Dual Pass Through*" -or
                         $_.devicename -like "*QLogic*" -or
                         $_.devicename -like "*X710T2LG*" -or
-                        $_.devicename -like "*E810XXVDA4*" -or
-                        $_.devicename -like "*E810CQDA2*"
+                        $_.devicename -like "*E810*"
                     }
 
     foreach ($storageController in $storageControllerList) {
@@ -441,8 +440,7 @@ Function GetDriverDetails {
             $osInv | Add-Member -type NoteProperty -name Value -Value $storage_device_map["QLogic"]
         }
         elseif(($storageController.DeviceName -like "*X710T2LG*") -or
-                ($storageController.DeviceName -like "*E810XXVDA4*") -or
-                ($storageController.DeviceName -like "*E810CQDA2*"))
+                ($storageController.DeviceName -like "*E810*"))
         {
             $osInv | Add-Member -type NoteProperty -name Value -Value $storage_device_map["Ethernet"]
         }


### PR DESCRIPTION
Added support for all Intel ethernet network adapter e810 series
Intel E810 ethernet network adapter list: https://ark.intel.com/content/www/us/en/ark/products/series/184846/100gbe-intel-ethernet-network-adapter-e810.html

Eg: ODT Output.
```
    {
      "Key": "intersight.server.os.driver.2.name",
      "Value": "Ethernet"
    },
    {
      "Key": "intersight.server.os.driver.2.description",
      "Value": "Cisco(R) E810XXVDA4 4x25/10 GbE SFP28 PCIe NIC"
    },
    {
      "Key": "intersight.server.os.driver.2.version",
      "Value": "1.14.104.0"
    }
```