### PR TITLE
CSCwk54400: adding support for UCSX-X10C-RAIDF controller

### DIFF
--- a/os-discovery-tool/getWindowsOsInvToIntersight.ps1
+++ b/os-discovery-tool/getWindowsOsInvToIntersight.ps1
@@ -366,6 +366,7 @@ Function GetDriverDetails {
     $storageControllerList = Get-CimInstance Win32_PnPSignedDriver -Computer $hostname | select DeviceName, DriverVersion |
                     where {
                         $_.devicename -like "*RAID SAS*" -or
+                        $_.devicename -like "*RAID Controller*" -or
                         $_.devicename -like "*SAS RAID*" -or
                         $_.devicename -like "*SWRAID*" -or
                         $_.devicename -like "*AHCI*" -or
@@ -393,7 +394,8 @@ Function GetDriverDetails {
         if(($storageController.DeviceName -like "*LSI*" -and
                 $storageController.DeviceName -like "*Mega*") -or
                 $storageController.DeviceName -like "*SAS RAID*" -or
-                $storageController.DeviceName -like "*RAID SAS*")
+                $storageController.DeviceName -like "*RAID SAS*" -or
+                $storageController.DeviceName -like "*RAID Controller*")
         {
             if ($storageController.DeviceName -like "*Tri-Mode*")
             {


### PR DESCRIPTION
adding support for UCSX-X10C-RAIDF controller
E.g: ODT output..
```
{
      "Value": "megasas35",
      "Key": "intersight.server.os.driver.3.name"
    },
    {
      "Value": "UCS X10c Compute RAID Controller",
      "Key": "intersight.server.os.driver.3.description"
    },
    {
      "Value": "7.726.1.0",
      "Key": "intersight.server.os.driver.3.version"
    }
```