### PR TITLE
Fix OS Discovery Tool Windows for Nvidia GPU detection

### DIFF
--- a/os-discovery-tool/getWindowsOsInvToIntersight.ps1
+++ b/os-discovery-tool/getWindowsOsInvToIntersight.ps1
@@ -294,8 +294,8 @@ Function GetDriverDetails {
                 foreach($cmd in $nvidiasmi)
                 {
                     # Determine if Graphics driver or compute driver is installed
-                    $command = "'$cmd' --query-gpu=driver_model.current --format=csv,no header"
-                    $mode = Invoke-Command -ComputerName $hostname -ScriptBlock ([ScriptBlock]::Create("& $command"))
+                    $command = "& `"$cmd`" --query-gpu=driver_model.current --format=csv,noheader"
+                    $mode = Invoke-Command -ComputerName $hostname -ScriptBlock {Invoke-Expression $using:command}
 
                     if($mode -contains "WDDM")
                     {


### PR DESCRIPTION
**Description:**
This pull request addresses an issue in the PowerShell script for detecting NVIDIA GPU drivers and their modes (Graphics or Compute). The current script "getWindowsOsInvToIntersight.ps1" has an error with the nvidia-smi command that prevents it from executing correctly in a remote PowerShell context.

**Issue Resolved**
Fixed the error where when a GPU (NVIDIA A100 in my lab) was unable to identify the model (TCC or WDDM) and a null value was being registered in the key. Due to this, the HCL part of Intersight was not being populated.

**What was changed**
- Corrected Command Construction: Removed single quotes around the path to nvidia-smi.exe when constructing the command string. Proper escaping is applied to handle spaces in paths. Also "no header" was changed to "noheader".

- Fixed Command Execution with Invoke-Expression: Modified how the nvidia-smi command is executed using Invoke-Expression to ensure it runs correctly in a remote session via Invoke-Command.