### PR TITLE
INTERSIGHT-32806: Windows Powershell ODT sending driver name as null

### DIFF
--- a/os-discovery-tool/getWindowsOsInvToIntersight.ps1
+++ b/os-discovery-tool/getWindowsOsInvToIntersight.ps1
@@ -366,7 +366,7 @@ Function GetDriverDetails {
     $storageControllerList = Get-CimInstance Win32_PnPSignedDriver -Computer $hostname | select DeviceName, DriverVersion |
                     where {
                         $_.devicename -like "*RAID SAS*" -or
-                        $_.devicename -like "*RAID Controller*" -or
+                        $_.devicename -like "*Compute RAID Controller*" -or
                         $_.devicename -like "*SAS RAID*" -or
                         $_.devicename -like "*SWRAID*" -or
                         $_.devicename -like "*AHCI*" -or


### PR DESCRIPTION
Windows Powershell ODT sending driver name as null for raid controller.

Hardware raid contains driver details, where as software raid does not contain any driver details. since the regex for fetching raid is “raid controller“ it is fetching both and sending the null value. It should consider only hardware raid so that driver name and other details will be sent properly.