### PR TITLE
CSCwo57488: nvidia output format wrongly specified

### DIFF
--- a/os-discovery-tool/getWindowsOsInvToIntersight.ps1
+++ b/os-discovery-tool/getWindowsOsInvToIntersight.ps1
@@ -292,7 +292,7 @@ Function GetDriverDetails {
                 foreach($cmd in $nvidiasmi)
                 {
                     # Determine if Graphics driver or compute driver is installed
-                    $command = "'$cmd' --query-gpu=driver_model.current --format=csv,no header"
+                    $command = "'$cmd' --query-gpu=driver_model.current --format='csv,noheader'"
                     $mode = Invoke-Command -ComputerName $hostname -ScriptBlock ([ScriptBlock]::Create("& $command"))
 
                     if($mode -contains "WDDM")


### PR DESCRIPTION
nvidia output format wrongly specified.
wrong format: --format=csv, no header
right format: --format='csv,noheader'

root cause: 'noheader' is a single word, but earlier it was specified as 'no header' which caused the issue.