### PR TITLE
Added support for nvidia gpu MCDM mode

### DIFF
--- a/os-discovery-tool/getWindowsOsInvToIntersight.ps1
+++ b/os-discovery-tool/getWindowsOsInvToIntersight.ps1
@@ -319,7 +319,7 @@ Function GetDriverDetails {
                         Write-host "[$hostname]: NVIDIA Graphics Driver is installed"
                         $osInv | Add-Member -type NoteProperty -name Value -Value "nvidia(graphics)"
                     }
-                    elseif($mode -contains "TCC")
+                    elseif(($mode -contains "TCC") -or ($mode -contains "MCDM"))
                     {
                         Write-host "[$hostname]: NVIDIA Compute Driver is installed"
                         $osInv | Add-Member -type NoteProperty -name Value -Value "nvidia(compute)"


### PR DESCRIPTION
ISSUE: driver name is not getting populated when the gpu was in MCDM mode.
Fix: driver name set as nvidia(compute) when it is configured in MCDM mode.